### PR TITLE
Implement comments

### DIFF
--- a/R/page_template_docx.R
+++ b/R/page_template_docx.R
@@ -656,8 +656,9 @@ get_page_footer_docx <- function(rs) {
       cnt <- cnt + max(lcnt, ccnt, rcnt)
       max_height <- max_height + max(lheight, cheight, rheight)
       
-      
-      trht <- get_row_height(max(round(rs$row_height * max(lcnt, ccnt, rcnt), max(lheight, cheight, rheight)) * conv)) 
+      text_height_emu <- round(rs$row_height * max(lcnt, ccnt, rcnt) * conv)
+      image_height_emu <- round(max(lheight, cheight, rheight) * conv)
+      trht <- get_row_height(max(text_height_emu, image_height_emu)) 
       
       # <w:tr> should end here for each row
       ret <- paste0(ret, '<w:tr>', trht, tret, "</w:tr>\n")

--- a/R/sizing_functions.R
+++ b/R/sizing_functions.R
@@ -595,7 +595,7 @@ get_col_widths_variable <- function(dat, ts, labels, font,
                                font_size, uom, gutter_width,
                                merge_label_row = TRUE) {
   
-  
+  dat_orig <- dat
   defs <- ts$col_defs
   if (uom == "cm") {
     #12.7
@@ -723,7 +723,7 @@ get_col_widths_variable <- function(dat, ts, labels, font,
   #print(ret)
   
   # Let widths on orig df override defaults
-  orig <- widths(dat)
+  orig <- widths(dat_orig)
   for (nm in names(orig)) {
     ret[[nm]] <- orig[[nm]]
   }

--- a/tests/testthat/test-docx.R
+++ b/tests/testthat/test-docx.R
@@ -2840,6 +2840,7 @@ test_that("docx-80: Plot with header/footer images works as expected.", {
     fp <- file.path(base_path, "docx/test80.docx")
     
     p <- ggplot(mtcars, aes(x=cyl, y=mpg)) + geom_point()
+    image_path <- file.path(base_path, "data/logo.jpg")
     
     plt <- create_plot(p, height = 4, width = 8, borders = c("none"))
     


### PR DESCRIPTION
Hi @dbosak01 ,
Thanks for your comments. Please see below summary:
1. Fix footer height of DOCX, which is the bug when I implemented issue #327
2. Fix the old bug, now width from use_attribute should work (issue #377 )
3. Add image path for unit test docx-80

As for other details, please see the mail I reply to you.
If there is any comments, please reply the mail to me.
Thank you.

Best,
Bill 